### PR TITLE
Add hint on how to show PCI ID in lsiutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ restrictions.
 
 Select your adapter.
 
+`59.  Dump PCI config space`
+
+If you have multiple adapters this helps figuring out the mapping between the lsiutil symbolic names and the PCI device ID.
+
+For example the combined location 001b00 corresponds to 0000:1b:00.0 when running lsirec later on.
+
 `46.  Upload FLASH section` → `5.  Complete (all sections)`
 
 Make a complete Flash backup to be safe.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Copy and paste these somewhere safe. Take special note of the SAS WWID.
 Wipe the whole Flash. This will take a while. Option number 3 excludes the
 manufacturing config pages, so you need both.
 
+Press `RETURN` to back up to the main menu.
+
 `2.  Download firmware (update the FLASH)`
 
 Flash the new firmware. Optionally, use

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Make a complete Flash backup to be safe.
 
 `68.  Show port state summary`
 
+`69.  Show board manufacturing information`
+
 Copy and paste these somewhere safe. Take special note of the SAS WWID.
 
 `33.  Erase non-volatile adapter storage` → `3.  FLASH`, then also


### PR DESCRIPTION
If you have multiple adapters it's not obvious what the mapping is between the lsiutil symbolic names and the PCI ID that lsirec uses.